### PR TITLE
Eliminacion Configuracion y modificacion del archivo nginx.conf y main.py en cuestion del routing interno

### DIFF
--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -1,24 +1,3 @@
-server {
-    listen 80;
-
-    server_name 3.145.178.31;
-
-    return 301 https://$server_name$request_uri;
-}
-
-server {
-    listen 443 ssl;
-
-    ssl_certificate /etc/ssl/algoritmos-geneticos.crt;
-    ssl_certificate_key /etc/ssl/algoritmos-geneticos.key;
-
-    server_name 3.145.178.31;
-
-    location / {
-        proxy_pass https://127.0.0.1:8000;
-    }
-}
-
 # Configuración para redirigir el tráfico HTTP a HTTPS
 server {
     listen 80;
@@ -48,9 +27,9 @@ server {
     add_header X-Frame-Options DENY;
     add_header X-XSS-Protection "1; mode=block";
 
-    # Configurar el proxy para el backend en el puerto 3000
+    # Configurar el proxy para el backend en el puerto 8000
     location / {
-        proxy_pass http://localhost:3000;  # Redirige a la aplicación en el puerto 3000
+        proxy_pass http://localhost:8000;  # Redirige a la aplicación en el puerto 8000
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -18,3 +18,42 @@ server {
         proxy_pass https://127.0.0.1:8000;
     }
 }
+
+# Configuración para redirigir el tráfico HTTP a HTTPS
+server {
+    listen 80;
+    server_name www.decisionesanaliticas.com decisionesanaliticas.com;
+
+    # Redirige todo el tráfico HTTP a HTTPS
+    return 301 https://$host$request_uri;
+}
+
+# Configuración del servidor HTTPS
+server {
+    listen 443 ssl;
+    server_name www.decisionesanaliticas.com decisionesanaliticas.com;
+
+    # Rutas a los certificados SSL de Let's Encrypt
+    ssl_certificate /etc/letsencrypt/live/decisionesanaliticas.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/decisionesanaliticas.com/privkey.pem;
+
+    # Configuraciones adicionales para seguridad SSL
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+    ssl_prefer_server_ciphers on;  # Prioriza los cifrados del servidor
+
+    # Seguridad adicional
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options DENY;
+    add_header X-XSS-Protection "1; mode=block";
+
+    # Configurar el proxy para el backend en el puerto 3000
+    location / {
+        proxy_pass http://localhost:3000;  # Redirige a la aplicación en el puerto 3000
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,9 @@ tomlkit==0.13.0
 typing_extensions==4.12.2
 uuid==1.30
 uvicorn==0.30.5
+nginx==1.18.0-0ubuntu1
+certbot==1.22.0
+python3-certbot-nginx==1.22.0
+python3-acme==1.22.0
+python3-cryptography==3.4.7
+openssl==1.1.1f-1ubuntu2

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -24,7 +24,6 @@ from paths import ERRORS_LOG
 from routers import algorithm, user
 
 # API
-
 app = FastAPI()
 
 app.add_middleware(
@@ -40,7 +39,7 @@ app.add_middleware(
 async def exception_middleware(
     request: Request, call_next: Callable[[Request], Awaitable[Any]]
 ):
-    """TODO"""
+    """Manejo de excepciones globales"""
     try:
         return await call_next(request)
     except Exception as e:  # pylint: disable=broad-except
@@ -55,12 +54,11 @@ app.include_router(algorithm.router)
 
 @app.get("/")
 async def root() -> dict[str, str]:
-    """Root de la api"""
+    """Root de la API"""
     return {"response": "root"}
 
 
 # Logging
-
 logging.basicConfig(
     level=logging.ERROR,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -69,16 +67,7 @@ logging.basicConfig(
     ],
 )
 
-# SSL
-
-SSL_ENABLED = False
-SSL_CERT = "cert.pem"
-SSL_KEY = "key.pem"
-
+# Ejecución del servidor
 if __name__ == "__main__":
-    if SSL_ENABLED:
-        uvicorn.run(
-            app, host="127.0.0.1", port=8000, ssl_certfile=SSL_CERT, ssl_keyfile=SSL_KEY
-        )
-    else:
-        uvicorn.run(app, host="127.0.0.1", port=8000)
+    # No es necesario SSL en FastAPI ya que NGINX maneja la terminación SSL
+    uvicorn.run(app, host="0.0.0.0", port=8000)  # Escucha en todas las interfaces, puerto 8000


### PR DESCRIPTION
#Se agregaron las siguientes dependencias a requirements.txt:

# NGINX (servidor web)
nginx==1.18.0-0ubuntu1

# Certbot (para gestionar certificados SSL)
certbot==1.22.0
python3-certbot-nginx==1.22.0

# Dependencias de Certbot
python3-acme==1.22.0
python3-cryptography==3.4.7

# OpenSSL (para manejar certificados SSL)
openssl==1.1.1f-1ubuntu2   # OpenSSL para creación y gestión de claves SSL

-----------------------------------------------------------------------------

#Dentro del archivo main.py para routing interno:

Desactivación de SSL en el backend: Se eliminó la lógica de configuración de SSL en FastAPI, ya que NGINX será quien maneje la terminación SSL.

Cambio en la dirección de escucha del servidor: FastAPI ahora escucha en todas las interfaces (0.0.0.0) para que NGINX pueda hacer proxy hacia él en el puerto 8000.

Eliminación de la redirección de HTTP a HTTPS: NGINX se encarga de redirigir todo el tráfico HTTP a HTTPS, por lo que FastAPI no maneja este aspecto.

Ajustes en la ejecución del servidor: FastAPI ahora solo ejecuta el servidor uvicorn sin SSL, permitiendo que el tráfico seguro sea gestionado por NGINX.

-----------------------------------------------------------------------------

#Configuración del hosting ubicado en el nginx.conf:

Redirección de HTTP a HTTPS: Garantiza que todo el tráfico HTTP sea redirigido automáticamente a HTTPS, asegurando que las conexiones sean seguras.

Configuración de SSL/TLS: Establece los certificados necesarios para la encriptación y configura los protocolos y cifrados seguros.

Cabeceras de Seguridad: Mejora la seguridad mediante políticas como HSTS y protecciones contra XSS y clickjacking.

Proxy hacia el backend: Redirige las solicitudes al servidor backend en un puerto diferente (8000), asegurando que las aplicaciones web funcionen de manera eficiente y segura.

-----------------------------------------------------------------------------

#Explicación del proceso de conexión por medio de Nginx en putty:

Abrir PuTTY.
En Host Name (or IP address), ingresa la dirección pública de tu instancia EC2 en AWS.

Ve a Connection > SSH > Auth y selecciona el archivo .ppk que generaste a partir de tu archivo .pem.

Haz clic en Open para conectar y, si es la primera vez, acepta la advertencia de seguridad.

#Instalación de Nginx y Certbot:

sudo apt-get update
sudo apt-get install nginx
sudo apt-get install certbot python3-certbot-nginx

#La obtención de un certificado SSL gratuito de Let's Encrypt. Usa el siguiente comando para obtener y configurar automáticamente el certificado para Nginx
sudo certbot --nginx

-----------------------------------------------------------------------------

#Configuración del archivo de Nginx(abrir el archivo):
sudo nano /etc/nginx/conf.d/decisionesanaliticas.com.conf

-----------------------------------------------------------------------------

#Codigo de configuración que va dentro del archivo:

# Configuración para redirigir el tráfico HTTP a HTTPS
server {
    listen 80;
    server_name www.decisionesanaliticas.com decisionesanaliticas.com;

    # Redirige todo el tráfico HTTP a HTTPS
    return 301 https://$host$request_uri;
}
# Configuración del servidor HTTPS
server {
    listen 443 ssl;
    server_name www.decisionesanaliticas.com decisionesanaliticas.com;
    # Rutas a los certificados SSL de Let's Encrypt
    ssl_certificate /etc/letsencrypt/live/decisionesanaliticas.com/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/decisionesanaliticas.com/privkey.pem;
    # Configuraciones adicionales para seguridad SSL
    ssl_protocols TLSv1.2 TLSv1.3;
    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
    ssl_prefer_server_ciphers on;  # Prioriza los cifrados del servidor
    # Seguridad adicional
    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
    add_header X-Content-Type-Options nosniff;
    add_header X-Frame-Options DENY;
    add_header X-XSS-Protection "1; mode=block";
    # Configurar el proxy para el backend en el puerto 8000
    location / {
        proxy_pass http://localhost:8000;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;<--(Si se tiene problemas se puede eliminar esta linea de codigo)
        proxy_set_header X-Forwarded-Proto $scheme;
    }
}

-----------------------------------------------------------------------------

#Verificar la configuración de nginx:
sudo nginx -t

-----------------------------------------------------------------------------

#Reinicio de nginx para aplicación de cambios:
sudo systemctl restart nginx

-----------------------------------------------------------------------------

#Carpeta con la llave .ppk e IP publica de la instancia de AWS usada:

https://drive.google.com/drive/folders/1u3AKDfNq2IfteVNihneTaJQo7Ylsrgs9?usp=sharing

Direction:
18.224.6.198